### PR TITLE
[28] - Grum errors fixed on Callback Koans

### DIFF
--- a/koans/CallbackFunctionsKoans.php
+++ b/koans/CallbackFunctionsKoans.php
@@ -7,6 +7,10 @@ use PHPUnit\Framework\TestCase;
 
 defined('__') or define('__', null);
 
+/**
+ * @SuppressWarnings(PHPMD.LongVariable)
+ */
+
 // Resources for learning about callbacks => https://www.php.net/manual/en/language.types.callable.php
 
 class CallbackFunctionsKoans extends TestCase
@@ -80,10 +84,10 @@ class CallbackFunctionsKoans extends TestCase
     public function usesArrayMapToChangeAnArrayUsingAFunction()
     {
         $numbers = [1, 2, 3, 4, 5];
-        $callback = function($number): int{
+        $callback = function ($number): int {
             return $number ** 2;
         };
-        
+
         $result = array_map($callback, $numbers);
 
         $this->assertEquals(__, $result);

--- a/koansSolutions/CallbackFunctionsKoansSolution.php
+++ b/koansSolutions/CallbackFunctionsKoansSolution.php
@@ -7,6 +7,10 @@ use PHPUnit\Framework\TestCase;
 
 defined('__') or define('__', null);
 
+/**
+ * @SuppressWarnings(PHPMD.LongVariable)
+ */
+
 // Resources for learning about callbacks => https://www.php.net/manual/en/language.types.callable.php
 
 class CallbackFunctionsKoansSolution extends TestCase
@@ -80,10 +84,10 @@ class CallbackFunctionsKoansSolution extends TestCase
     public function usesArrayMapToChangeAnArrayUsingAFunction()
     {
         $numbers = [1, 2, 3, 4, 5];
-        $callback = function($number): int{
+        $callback = function ($number): int {
             return $number ** 2;
         };
-        
+
         $result = array_map($callback, $numbers);
 
         $this->assertEquals([1, 4, 9, 16, 25], $result);


### PR DESCRIPTION
**Issue**
- Resolves #28 

**Solution**
- There was a small error on PHPCS and PHPMD also complained about two variables because they were very long although it doesn't seem to me and I think they have a good naming, that's why I added the SupressWarning in this case.

